### PR TITLE
Session submission

### DIFF
--- a/config/default/core.entity_form_display.node.session.default.yml
+++ b/config/default/core.entity_form_display.node.session.default.yml
@@ -36,36 +36,19 @@ content:
     third_party_settings: {  }
   field_categories:
     weight: 35
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-  field_event_ref:
-    weight: 32
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: options_buttons
   field_level:
     weight: 36
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: options_buttons
   field_session_status:
     weight: 34
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: options_select
   field_time_slot:
     weight: 33
     settings: {  }
@@ -103,4 +86,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_event_ref: true

--- a/docroot/modules/custom/dcb_sessions/dcb_sessions.module
+++ b/docroot/modules/custom/dcb_sessions/dcb_sessions.module
@@ -5,10 +5,36 @@
  * Contains dcb_sessions.module.
  */
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Cache\Cache;
+
+
+/**
+ * Implements hook_entity_field_access().
+ */
+function dcb_sessions_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+  $entity_type_id = $field_definition->getTargetEntityTypeId();
+  $field_name = $field_definition->getName();
+
+  // stop users who don't have the 'administer nodes' permission
+  // from editing various fields on 'session' nodes
+  if ($entity_type_id === 'node') {
+    if ($field_name === 'field_session_status' || $field_name === 'field_time_slot') {
+      if ($operation === 'edit') {
+        return AccessResult::forbiddenIf(!$account->hasPermission('administer nodes'));
+      }
+    }
+  }
+
+  // otherwise, this module itself doesn't care
+  return AccessResult::neutral();
+}
+
 
 /**
  * Implements hook_help().
@@ -32,33 +58,6 @@ function dcb_sessions_help($route_name, RouteMatchInterface $route_match) {
  */
 function dcb_sessions_entity_type_build(array &$entity_types) {
   $entity_types['node']->setFormClass('session_submission', 'Drupal\node\NodeForm');
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- * @param $form
- * @param \Drupal\Core\Form\FormStateInterface $form_state
- * @param $form_id
- */
-function dcb_sessions_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-
-  switch ($form_id) {
-    case "node_session_form":
-
-      $account = \Drupal::currentUser();
-      // redirect users from the default node session form
-      if ($account->id() != 1 && !in_array('administrator', $account->getRoles())) {
-        $response = new RedirectResponse(\Drupal::url('user.page'));
-        $response->send();
-      }
-
-      break;
-
-    case "node_session_session_submission_form":
-      // add additional submit handler
-      $form['actions']['submit']['#submit'][] = 'dcb_sessions_form_submission_handler';
-      break;
-  }
 }
 
 /**

--- a/docroot/themes/custom/dcb/templates/form--node-session-edit-form.html.twig
+++ b/docroot/themes/custom/dcb/templates/form--node-session-edit-form.html.twig
@@ -12,6 +12,8 @@
  * @ingroup themeable
  */
 #}
-<form{{ attributes }}>
-  {{ children }}
-</form>
+<div class="container dcb-form-wrapper">
+  <form{{ attributes }}>
+    {{ children }}
+  </form>
+</div>


### PR DESCRIPTION
This adds a hook_entity_field_access() implementation to the dcb_sessions module, which restricts write access to the approved/time fields on session submissions. This makes the logic that was in the form_alter redundant, so I've removed that.
